### PR TITLE
fix: Adding gradle task to generate RSA Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
-src/main/resources/app.key
+src/main/resources/keys/*
 src/main/resources/application.properties
-src/main/resources/app.pub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM gradle:8.14.3-jdk17-jammy AS build
-COPY --chown=gradle:gradle . /home/gradle/src
-WORKDIR /home/gradle/src
+COPY --chown=gradle:gradle . /gradle
+WORKDIR /gradle
 RUN gradle bootJar --no-daemon
 
 FROM eclipse-temurin:17-jdk-jammy
 WORKDIR /ecommerce
-COPY --from=build /home/gradle/src/build/libs/*.jar /ecommerce/app.jar
+COPY --from=build /gradle/src/main/resources/keys /ecommerce/keys
+COPY --from=build /gradle/build/libs/*.jar /ecommerce/app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/ecommerce/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,8 @@
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.util.Base64
+
 plugins {
 	java
 	id("org.springframework.boot") version "3.5.3"
@@ -51,4 +56,42 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+tasks.register("generateJwtKeys") {
+	group = "build"
+	description = "Generates RSA public and private keys for JWT"
+
+	doLast {
+		val keyDir = file("src/main/resources/keys").apply { mkdirs() }
+
+		// Generate RSA Key Pair (2048-bit)
+		val keyPairGenerator = KeyPairGenerator.getInstance("RSA").apply {
+			initialize(2048)
+		}
+		val keyPair = keyPairGenerator.generateKeyPair()
+		val publicKey = keyPair.public as RSAPublicKey
+		val privateKey = keyPair.private as RSAPrivateKey
+
+		// Write keys in PEM format
+		fun encodeKeyToPem(key: ByteArray, type: String): String {
+			val base64Key = Base64.getEncoder().encodeToString(key)
+			val key = base64Key.chunked(64).joinToString("\n");
+
+			return "-----BEGIN $type KEY-----\n${key}\n-----END $type KEY-----"
+		}
+
+		val publicPem = encodeKeyToPem(publicKey.encoded, "PUBLIC")
+		val privatePem = encodeKeyToPem(privateKey.encoded, "PRIVATE")
+
+		// Save keys to files
+		keyDir.resolve("public.pub").writeText(publicPem)
+		keyDir.resolve("private.key").writeText(privatePem)
+
+		println("\uD83D\uDD11 Generated JWT keys in ${keyDir.path}")
+	}
+}
+
+tasks.named("bootJar") {
+	dependsOn("generateJwtKeys")
 }

--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
       dockerfile: Dockerfile
     container_name: ecommerce-api
     ports:
-      - "9001:8080"
+      - "8080:8080"
     depends_on:
       - mysql
     environment:


### PR DESCRIPTION
- Added gradle task 'generateRsaKeys' that runs before bootJar task
- Added RSA Keys to Dockerfile container
- Fixed API port to be only 8080
- Standardization to save RSA Keys in /keys folder in the src/main/resources